### PR TITLE
Added block number to stability deposit change

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -245,6 +245,11 @@ type StabilityDepositChange implements Change @entity {
   depositedAmountAfter: BigDecimal!
 
   collateralGain: BigDecimal
+
+  """
+  Block number is needed internally to calculate gains per user
+  """
+  blockNumber: Int!
 }
 
 type PriceChange implements Change @entity {

--- a/src/entities/StabilityDeposit.ts
+++ b/src/entities/StabilityDeposit.ts
@@ -66,6 +66,7 @@ function updateStabilityDepositByOperation(
   let stabilityDepositChange = createStabilityDepositChange(event);
 
   stabilityDepositChange.stabilityDeposit = stabilityDeposit.id;
+  stabilityDepositChange.blockNumber = event.block.number.toI32();
   stabilityDepositChange.stabilityDepositOperation = operation;
   stabilityDepositChange.depositedAmountBefore =
     stabilityDeposit.depositedAmount;


### PR DESCRIPTION
@creed-victor I wanted to see if I could get the SP gains feature working - this is a very small change relating to that feature, just adding the block number to the stability deposit entity so it can be searched by block number